### PR TITLE
Fix OS Command Injection Vulnerability

### DIFF
--- a/dotstrings/genstrings.py
+++ b/dotstrings/genstrings.py
@@ -21,10 +21,16 @@ def _convert_to_utf8(file_path: str) -> None:
 
     temp_file_path = tempfile.mktemp()
 
-    iconv_command = f'iconv -f UTF-16 -t UTF-8 "{file_path}" > "{temp_file_path}"'
+    iconv_command = ["iconv", "-f", "UTF-16", "-t", "UTF-8", file_path]
 
-    if subprocess.run(iconv_command, shell=True, check=False).returncode != 0:
+    result = subprocess.run(
+        iconv_command, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    if result.returncode != 0:
         raise DotStringsException("Unable to convert from UTF-16 to UTF-8!")
+
+    with open(temp_file_path, "wb") as f:
+        f.write(result.stdout)
 
     shutil.move(temp_file_path, file_path)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dotstrings"
-version = "3.1.5"
+version = "3.1.6"
 description = "Tools for dealing with the .strings files for iOS and macOS"
 
 license = "MIT"


### PR DESCRIPTION
## Summary

  This PR fixes a **critical OS command injection vulnerability** (MSRC Case #115391, VULN-185735) in the `_convert_to_utf8` function in `genstrings.py`. The vulnerability allowed arbitrary command execution through maliciously crafted file
  paths.

  ## Vulnerability Details

  **MSRC Case**: #115391
  **Submission**: VULN-185735
  **Severity**: Security Risk
  **CWE**: CWE-78 (OS Command Injection)

  ### Root Cause

  The vulnerable code constructed shell commands using f-string interpolation with unsanitized user input, then executed them with `shell=True`:

  ```python
  # VULNERABLE CODE
  iconv_command = f'iconv -f UTF-16 -t UTF-8 "{file_path}" > "{temp_file_path}"'
  subprocess.run(iconv_command, shell=True, check=False)
```

  Attack Vector

  An attacker controlling a filename could inject arbitrary commands:

```python
  file_path = 'innocent.txt"; rm -rf /; echo "'
  # Executes: iconv ... "innocent.txt"; rm -rf /; echo "" > "/tmp/..."
  #                                     ^^^^^^^^^^^
  #                                     Injected commands executed!
```

  Changes Made

  1. Secure Command Execution (dotstrings/genstrings.py)

  Replaced shell command string construction with argument list and removed shell=True:

```python
  # SECURE CODE
  iconv_command = ['iconv', '-f', 'UTF-16', '-t', 'UTF-8', file_path]
  result = subprocess.run(iconv_command, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  if result.returncode != 0:
      raise DotStringsException("Unable to convert from UTF-16 to UTF-8!")

  with open(temp_file_path, 'wb') as f:
      f.write(result.stdout)
```

  Why This is Secure:
  - Arguments are passed as a list, not a shell command string
  - No shell=True, so no shell interpretation occurs
  - Special characters in file_path (;, |, $(), etc.) are treated as literal filename characters
  - Output is captured via stdout=PIPE instead of shell redirection (>)

  2. Version Bump (pyproject.toml)

  Updated version from 3.1.5 → 3.1.6 to reflect the security patch.

  Security Impact

  - Before: Any code path processing untrusted filenames through _convert_to_utf8 was vulnerable to OS command injection
  - After: Filenames are safely passed as arguments, eliminating command injection risk entirely

  Testing

  The fix maintains identical functional behavior:
  - Normal filenames work as before
  - Filenames with spaces, quotes, and special characters are now handled safely
  - Error handling remains unchanged
  - The only difference: malicious filenames no longer execute injected commands

  Compatibility

  - ✅ No breaking changes to the public API
  - ✅ No changes to function signatures
  - ✅ Backward compatible with all existing usage

  Compliance

  This fix addresses the MSRC security case and follows OWASP guidelines for preventing command injection vulnerabilities in Python.